### PR TITLE
Fix Tracing when using external providers

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -33,7 +33,8 @@
       "Bash(task ci)",
       "Bash(task format)",
       "Bash(task check)",
-      "Bash(task fix)"
+      "Bash(task fix)",
+      "Bash(OPENAI_API_BASE=https://example.com OPENAI_API_KEY=test uv run memory-banker --help)"
     ],
     "deny": []
   }

--- a/memory_banker/cli.py
+++ b/memory_banker/cli.py
@@ -20,6 +20,7 @@ class MemoryBankerCLI:
     ):
         # Import OpenAI agents after potential tracing disable
         from agents.extensions.models.litellm_model import LitellmModel
+
         from .agents import MemoryBankAgents
 
         self.project_path = project_path

--- a/memory_banker/cli.py
+++ b/memory_banker/cli.py
@@ -3,10 +3,8 @@ import os
 from pathlib import Path
 
 import click
-from agents.extensions.models.litellm_model import LitellmModel
 from rich.console import Console
 
-from .agents import MemoryBankAgents
 from .memory_bank import MemoryBank
 from .progress import create_simple_tracker
 
@@ -20,6 +18,10 @@ class MemoryBankerCLI:
         api_base: str | None = None,
         timeout: int = 300,
     ):
+        # Import OpenAI agents after potential tracing disable
+        from agents.extensions.models.litellm_model import LitellmModel
+        from .agents import MemoryBankAgents
+        
         self.project_path = project_path
         self.model = model
         self.api_key = api_key or os.getenv("OPENAI_API_KEY")

--- a/memory_banker/cli.py
+++ b/memory_banker/cli.py
@@ -21,7 +21,7 @@ class MemoryBankerCLI:
         # Import OpenAI agents after potential tracing disable
         from agents.extensions.models.litellm_model import LitellmModel
         from .agents import MemoryBankAgents
-        
+
         self.project_path = project_path
         self.model = model
         self.api_key = api_key or os.getenv("OPENAI_API_KEY")


### PR DESCRIPTION
- Move imports of LitellmModel and MemoryBankAgents inside the CLI class initializer to avoid premature loading and enable tracing disablement.
- Add a new Bash task with environment variables for testing the CLI help command, improving flexibility and supporting better debugging and testing workflows.